### PR TITLE
Red text

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ True
 {'closure_y', 'global_x'}
 >>> paranoid_g()
 ```
-<pre style='color:red'>NameError: Undefined variables: 'global_x', 'closure_y'.
-Use `bind` method to assign values for these names before calling.</pre>
+```diff
+- NameError: Undefined variables: 'global_x', 'closure_y'.
+- Use `bind` method to assign values for these names before calling.</pre>
+```
 ```python
 >>> new_g = paranoid_g.bind({'global_x': 100, 'closure_y': 200})
 >>> new_g.missing

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ True
 ```
 ```diff
 - NameError: Undefined variables: 'global_x', 'closure_y'.
-- Use `bind` method to assign values for these names before calling.</pre>
+- Use `bind` method to assign values for these names before calling.
 ```
 ```python
 >>> new_g = paranoid_g.bind({'global_x': 100, 'closure_y': 200})


### PR DESCRIPTION
HTML styling tags get removed in github and PyPI, which is reasonable sanitation precautions.  Let's try using `diff` code block to show the exception message in red.