### PR TITLE
Inner names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ True
 def step2(d):
     e = max(a + d, b + c)
 
->>> step2.outer_scope == {'a': 1, 'b': 2, 'c': 3, '__builtins__': __builtins__}
+>>> step2.outer_scope == {'a': 1, 'b': 2, 'c': 3}
 True
 >>> scope2 = step2(4)
 >>> scope2 == {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}

--- a/innerscope/tests/test_core.py
+++ b/innerscope/tests/test_core.py
@@ -1,7 +1,10 @@
 import pytest
-from pytest import raises
+import builtins
 import innerscope
+from pytest import raises
 from innerscope import scoped_function
+
+global_x = 1
 
 
 def test_no_args():
@@ -21,6 +24,7 @@ def test_no_args():
 
     def check(f2bound):
         assert not f2bound.missing
+        assert f2bound.inner_names == {"c"}
         assert f2bound.outer_scope["b"] == 2
         scope2 = f2bound()
         assert scope2 == dict(b=2, c=3)
@@ -37,9 +41,9 @@ def test_no_args():
     check(sf2.bind({"b": 2}))
     check(sf2.bind(scope1))
     check(scope1.bindto(sf2))
-    check(scope1.bindto(sf2.orig_func))
+    check(scope1.bindto(sf2.func))
     check(scoped_function(sf2, scope1))
-    check(scoped_function(sf2.orig_func, scope1))
+    check(scoped_function(sf2.func, scope1))
 
 
 def test_no_args_call():
@@ -170,13 +174,29 @@ def test_use_closure():
 
 def test_use_globals():
     def f1():
-        x = innerscope
+        x = global_x
 
     assert not scoped_function(f1, use_globals=True).missing
-    assert scoped_function(f1, use_globals=False).missing == {"innerscope"}
-    assert scoped_function(f1, use_globals=True)() == {"x": innerscope, "innerscope": innerscope}
-    scope = scoped_function(f1, {"innerscope": 1}, use_globals=True)()
-    assert scope == {"x": 1, "innerscope": 1}
+    assert scoped_function(f1, use_globals=False).missing == {"global_x"}
+    assert scoped_function(f1, use_globals=True)() == {"x": 1, "global_x": 1}
+    scope = scoped_function(f1, {"global_x": 1}, use_globals=True)()
+    assert scope == {"x": 1, "global_x": 1}
+
+
+def test_closures():
+    def f(arg_f):
+        nonlocal_y = 2
+
+        def g(arg_g):
+            local_z = global_x + nonlocal_y + arg_f + arg_g
+
+        return g
+
+    assert scoped_function(f).inner_names == {"arg_f", "nonlocal_y", "g"}
+    g = f(1)
+    scoped_g = scoped_function(g)
+    assert scoped_g.inner_names == {"arg_g", "local_z"}
+    assert scoped_g.outer_scope == {"global_x": 1, "arg_f": 1, "nonlocal_y": 2}
 
 
 def test_has_builtins():

--- a/innerscope/tests/test_core.py
+++ b/innerscope/tests/test_core.py
@@ -46,6 +46,14 @@ def test_no_args():
     check(scoped_function(sf2.func, scope1))
 
 
+def test_repr():
+    @innerscope.call
+    def f():
+        x = 1
+
+    assert repr(f) == "Scope({'x': 1})"
+
+
 def test_no_args_call():
     def f1():
         a = 1
@@ -197,6 +205,7 @@ def test_closures():
     scoped_g = scoped_function(g)
     assert scoped_g.inner_names == {"arg_g", "local_z"}
     assert scoped_g.outer_scope == {"global_x": 1, "arg_f": 1, "nonlocal_y": 2}
+    assert scoped_g(3) == {"arg_f": 1, "nonlocal_y": 2, "global_x": 1, "arg_g": 3, "local_z": 7}
 
 
 def test_has_builtins():

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: Implementation :: CPython",
     ],
 )


### PR DESCRIPTION
- Add `my_scoped_function.inner_names` set.
- Make closures only show up in `my_scope.outer_scope`.
- Don't include `"__builtins__"` in any `inner_scope` or `outer_scope`.
    - To do this, we create the global dict in `ScopedFunction.__call__`