### PR TITLE
Allow wrapped functions to define functions and classes.

### DIFF
--- a/innerscope/core.py
+++ b/innerscope/core.py
@@ -84,7 +84,7 @@ def _get_repr_set(title, names):
 
 
 class Scope(Mapping):
-    """ A read-only mapping of the inner and outer scope of a function.
+    """A read-only mapping of the inner and outer scope of a function.
 
     This is the return value when a `ScopedFunction` is called.
     """
@@ -107,7 +107,7 @@ class Scope(Mapping):
         return len(self.outer_scope) + len(self.inner_scope)
 
     def bindto(self, func, *, use_closures=None, use_globals=None):
-        """ Bind the variables of this object to a function.
+        """Bind the variables of this object to a function.
 
         >>> @call
         ... def haz_cheezburger():
@@ -151,7 +151,7 @@ class Scope(Mapping):
         return ScopedFunction(func, self, use_closures=use_closures, use_globals=use_globals)
 
     def call(self, func, *args, **kwargs):
-        """ Bind the variables of this object to a function and call the function.
+        """Bind the variables of this object to a function and call the function.
 
         >>> @call
         ... def haz_cheezburger():
@@ -192,7 +192,7 @@ class Scope(Mapping):
         return self.bindto(func)(*args, **kwargs)
 
     def callwith(self, *args, **kwargs):
-        """ ♪ But here's my number, so call me maybe ♪
+        """♪ But here's my number, so call me maybe ♪
 
         >>> @call
         ... def haz_cheezburger():
@@ -291,7 +291,7 @@ class Scope(Mapping):
 
 
 class ScopedFunction:
-    """ Use to expose the inner scope of a wrapped function after being called.
+    """Use to expose the inner scope of a wrapped function after being called.
 
     The wrapped function should have no return statements.  Instead of a return value,
     a `Scope` object is returned when called, which is a Mapping of the inner scope.
@@ -398,7 +398,9 @@ class ScopedFunction:
         else:
             # stacksize must be at least 3, because we make a length three tuple
             self._code = code.replace(
-                co_code=co_code, co_names=co_names, co_stacksize=max(code.co_stacksize, 3),
+                co_code=co_code,
+                co_names=co_names,
+                co_stacksize=max(code.co_stacksize, 3),
             )
 
     def __call__(self, *args, **kwargs):
@@ -482,7 +484,7 @@ class ScopedFunction:
         )
 
     def bind(self, *mappings, **kwargs):
-        """ Bind variables to a function's outer scope.
+        """Bind variables to a function's outer scope.
 
         This returns a new ScopedFunction object and leaves the original unmodified.
 
@@ -548,7 +550,7 @@ class ScopedFunction:
 
 
 def scoped_function(func=None, *mappings, use_closures=True, use_globals=True):
-    """ Use to expose the inner scope of a wrapped function after being called.
+    """Use to expose the inner scope of a wrapped function after being called.
 
     The wrapped function should have no return statements.  Instead of a return value,
     a `Scope` object is returned when called, which is a Mapping of the inner scope.
@@ -594,7 +596,7 @@ def scoped_function(func=None, *mappings, use_closures=True, use_globals=True):
 
 
 def bindwith(*mappings, **kwargs):
-    """ Bind variables to a function's outer scope, but don't yet call the function.
+    """Bind variables to a function's outer scope, but don't yet call the function.
 
     >>> @bindwith(cheez='cheddar')
     ... def makez_cheezburger():
@@ -622,7 +624,7 @@ def bindwith(*mappings, **kwargs):
 
 
 def call(func, *args, **kwargs):
-    """ Useful for making simple pipelines to go from functions to scopes.
+    """Useful for making simple pipelines to go from functions to scopes.
 
     >>> @call
     ... def haz_cheezburger():
@@ -663,7 +665,7 @@ def call(func, *args, **kwargs):
 
 
 def callwith(*args, **kwargs):
-    """ Useful for making simple pipelines to go from functions with arguments to scopes.
+    """Useful for making simple pipelines to go from functions with arguments to scopes.
 
     >>> @callwith(extra_cheez_pleez=True)
     ... def haz_cheezburger(extra_cheez_pleez=False):

--- a/innerscope/tests/test_core.py
+++ b/innerscope/tests/test_core.py
@@ -389,3 +389,80 @@ def test_default_args():
         pass
 
     assert f == {"w": 0, "x": 1, "y": 2, "z": 3, "args": (), "kwargs": {}}
+
+
+def test_list_comprehension():
+    closure_val = 2
+
+    def f():
+        y = [i for i in range(global_x)]
+        z = [j for j in range(closure_val)]
+
+    assert innerscope.call(f) == {"y": [0], "z": [0, 1], "global_x": 1, "closure_val": 2}
+    scoped_f = scoped_function(f, use_globals=False, use_closures=False)
+    assert scoped_f.missing == {"global_x", "closure_val"}
+    scope = scoped_f.bind(global_x=2, closure_val=1)()
+    assert scope == {"y": [0, 1], "z": [0], "global_x": 2, "closure_val": 1}
+
+
+def test_inner_functions():
+
+    def f():
+        closure_val = 10
+
+        def g():
+            y = global_x + 1
+            z = closure_val + 1
+            return y, z
+
+    scope = innerscope.call(f)
+    assert scope.keys() == {"closure_val", "g", "global_x"}
+    assert scope["g"]() == (2, 11)
+    scoped_f = scoped_function(f, use_globals=False, use_closures=False)
+    assert scoped_f.missing == {"global_x"}
+    scope = scoped_f.bind(global_x=2)()
+    assert scope.keys() == {"closure_val", "g", "global_x"}
+    assert scope["g"]() == (3, 11)
+
+
+def test_inner_class():
+    def f1():
+        class A:
+            x = global_x + 1
+
+    scope = innerscope.call(f1)
+    assert scope.keys() == {"A", "global_x"}
+    assert scope["A"].x == 2
+    scoped_f = scoped_function(f1, use_globals=False, use_closures=False)
+    assert scoped_f.missing == {"global_x"}
+    assert scoped_f.bind(global_x=2)()["A"].x == 3
+
+    a = 10
+
+    def f2():
+        b = 100
+
+        def g(self):
+            pass
+
+        class A:
+            x = global_x + 1
+
+            def __init__(self):
+                pass
+
+            y = x + 1
+            z = a + b
+            gm = g
+
+    scope = innerscope.call(f2)
+    assert scope.outer_scope.keys() == {"a", "global_x"}
+    assert scope.inner_scope.keys() == {"b", "g", "A"}
+    assert scope["A"].x == 2
+    assert scope["A"].z == 110
+    assert scope["A"]().gm() is None
+    scoped_f = scoped_function(f2, use_globals=False, use_closures=False)
+    assert scoped_f.missing == {"a", "global_x"}
+    scope = scoped_f.bind(a=20, global_x=2)()
+    assert scope["A"].x == 3
+    assert scope["A"].z == 120

--- a/innerscope/tests/test_core.py
+++ b/innerscope/tests/test_core.py
@@ -406,7 +406,6 @@ def test_list_comprehension():
 
 
 def test_inner_functions():
-
     def f():
         closure_val = 10
 


### PR DESCRIPTION
We need to recurse into functions and classes defined within a wrapped function in order to determine which globals we need.