### PR TITLE
Add Python 3.12 support via "trace" method

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    changes: false
+comment:
+  layout: "header, diff"
+  behavior: default
+github_checks:
+  annotations: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     name: pre-commit-hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,11 +11,11 @@ jobs:
     if: github.repository == 'eriknw/innerscope'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
       - name: Install build dependencies
@@ -24,7 +24,7 @@ jobs:
           python -m pip install build twine
       - name: Build wheel and sdist
         run: python -m build --sdist --wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: releases
           path: dist
@@ -33,7 +33,7 @@ jobs:
         run: python -m twine check --strict dist/*
       - name: Publish to PyPI
         if: contains(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@v1.8.6
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,11 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -39,4 +39,4 @@ jobs:
           coverage xml
           coverage report --show-missing
       - name: codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9", "pypy-3.10"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,27 +29,14 @@ jobs:
           pip install -e . --no-deps
       - name: PyTest
         run: |
-          coverage run --branch -m pytest --doctest-modules --method bytecode
+          if [[ ${{ matrix.python-version }} != '3.12' ]]; then
+            coverage run --branch -m pytest --doctest-modules --method bytecode
+          fi
           coverage run -a --branch -m pytest --doctest-modules --method trace
           pytest --doctest-modules --method trace
       - name: Coverage
-        if: (! contains(matrix.python-version, 'pypy'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-          COVERALLS_FLAG_NAME: ${{ matrix.python-version}}
-          COVERALLS_PARALLEL: true
         run: |
-          pip install coveralls
+          coverage xml
           coverage report --show-missing
-          coveralls --service=github
-
-  finish:
-    needs: test
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel-finished: true
+      - name: codecov
+        uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ default_language_version:
     python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -33,58 +33,58 @@ repos:
       - id: name-tests-test
         args: ["--pytest-test-first"]
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.13
+    rev: v0.16
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
   # I don't yet trust ruff to do what autoflake does
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.1.1
+    rev: v2.2.1
     hooks:
       - id: autoflake
         args: [--in-place]
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.6.0
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 24.2.0
     hooks:
       - id: black
-  # - repo: https://github.com/charliermarsh/ruff-pre-commit
-  #   rev: v0.0.272
+  # - repo: https://github.com/astral-sh/ruff-pre-commit
+  #   rev: v0.1.14
   #   hooks:
   #     - id: ruff
   #       args: [--fix-only, --show-fixes]
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies: &flake8_dependencies
         # These versions need updated manually
-        - flake8==6.0.0
+        - flake8==7.0.0
         - flake8-comprehensions==3.12.0
-        - flake8-bugbear==23.6.5
-        - flake8-simplify==0.20.0
+        - flake8-bugbear==24.2.6
+        - flake8-simplify==0.21.0
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0
     hooks:
       - id: yesqa
         additional_dependencies: *flake8_dependencies
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
       - id: codespell
         types_or: [python, rst, markdown]
         additional_dependencies: [tomli]
         files: ^(innerscope|docs)/
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.272
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
     hooks:
       - id: ruff
   # `pyroma` may help keep our package standards up to date if best practices change.
@@ -95,6 +95,6 @@ repos:
       - id: pyroma
         args: [-n, "10", .]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: no-commit-to-branch  # no commit directly to main

--- a/innerscope/cfg.py
+++ b/innerscope/cfg.py
@@ -1,1 +1,7 @@
-default_method = "bytecode"
+import sys
+
+if sys.version_info < (3, 12):
+    default_method = "bytecode"
+else:
+    default_method = "trace"
+del sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
@@ -70,7 +71,7 @@ dirty_template = "{tag}+{ccount}.g{sha}.dirty"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.isort]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
@@ -112,9 +113,14 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-# https://github.com/charliermarsh/ruff/
+# https://github.com/astral-sh/ruff/
 line-length = 100
 target-version = "py38"
+[tool.ruff.lint]
+unfixable = [
+    "F841",  # unused-variable (Note: can leave useless expression)
+    "B905",  # zip-without-explicit-strict (Note: prefer `zip(x, y, strict=True)`)
+]
 select = [
     "ALL",
 ]
@@ -171,7 +177,7 @@ ignore = [
     "PD",  # pandas-vet (Intended for scripts that use pandas, not libraries)
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports (w/o defining `__all__`)
 "innerscope/tests/*py" = [
     "S101", "S301", "T201", "D103", "D100",  # Allow assert, print, pickle, and no docstring
@@ -179,6 +185,6 @@ ignore = [
 ]
 "innerscope/tests/test_repr.py" = ["E501"]
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Simple setuptools script; see pyproject.toml for package info."""
+
 from setuptools import setup
 
 setup()


### PR DESCRIPTION
We still need to update this to handle the bytecode changes in Python 3.12. This does make some changes to better support `method="trace"`. Also, update linting.